### PR TITLE
deb-src are unnecessary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,8 @@ SHELL ["/bin/bash", "-c"]
 
 RUN echo '' > /etc/apt/sources.list
 RUN echo 'deb http://deb.debian.org/debian stretch main contrib non-free' >> /etc/apt/sources.list
-RUN echo 'deb-src http://deb.debian.org/debian stretch main contrib non-free' >> /etc/apt/sources.list
 RUN echo 'deb http://deb.debian.org/debian stretch-updates main contrib non-free' >> /etc/apt/sources.list
-RUN echo 'deb-src http://deb.debian.org/debian stretch-updates main contrib non-free' >> /etc/apt/sources.list
 RUN echo 'deb http://security.debian.org/debian-security/ stretch/updates main contrib non-free' >> /etc/apt/sources.list
-RUN echo 'deb-src http://security.debian.org/debian-security/ stretch/updates main contrib non-free' >> /etc/apt/sources.list
 
 RUN apt-get update
 RUN mkdir -p /usr/share/man/man1


### PR DESCRIPTION
They only increase the amount of data to be downloaded unnecessarily (`apt-get source` is never used, for example, and thus `deb-src` are not required)